### PR TITLE
Added API tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "ezsystems/ezpublish-api": "*",
+        "ezsystems/ezpublish-api": "dev-query_debug_output",
         "symfony/symfony": "*",
         "sensio/generator-bundle": "2.2.*"
     },
@@ -22,5 +22,11 @@
     "autoload": {
         "psr-0": {"EzSystems\\QueryBuilderBundle": ""}
     },
-    "target-dir": "EzSystems/QueryBuilderBundle"
+    "target-dir": "EzSystems/QueryBuilderBundle",
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/bdunogier/ezpublish-api"
+        }
+    ]
 }

--- a/eZ/Publish/API/QueryBuilder/Tests/BaseTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/BaseTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * File containing the BaseTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests;
+use EzSystems\QueryBuilderBundle\eZ\Publish\Core\QueryBuilder\CriterionFactoryWorkerRegistry;
+use EzSystems\QueryBuilderBundle\eZ\Publish\Core\QueryBuilder\QueryBuilder;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Base QueryBuilder API test.
+ * Provides facilities to validate a building chain
+ */
+abstract class BaseTest extends PHPUnit_Framework_TestCase
+{
+    /** @var \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Builder\QueryBuilder */
+    private $queryBuilder;
+
+    public function setUp()
+    {
+        $this->queryBuilder = new QueryBuilder(
+            new CriterionFactoryWorkerRegistry()
+        );
+    }
+
+    /**
+     * @return \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Builder\QueryBuilder
+     */
+    protected function getQueryBuilder()
+    {
+        return $this->queryBuilder;
+    }
+
+    /**
+     * Tests that the current query is equals (as a string) to $expectedQueryString
+     * @param string $expectedQueryString
+     */
+    protected function assertQueryEquals( $expectedQueryString )
+    {
+        $this->assertEquals(
+            $expectedQueryString,
+            (string)$this->queryBuilder->getQuery()
+        );
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Builder/SortClauseBuilderTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Builder/SortClauseBuilderTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * File containing the SortClauseBuilderTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Builder;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\BaseTest;
+
+class SortClauseBuilderTest extends BaseTest
+{
+    /**
+     * Tests that calling getQuery() after building sort clauses returns the query like the query builder does
+     */
+    public function testGetQuery()
+    {
+        self::assertEquals(
+            $this->getQueryBuilder()
+                ->contentTypeIdentifier()->eq( 'article' )
+                ->sortBy()->contentName()->ascending()->getQuery(),
+            $this->getQueryBuilder()->getQuery()
+        );
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/AuthorFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/AuthorFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class AuthorFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'authorField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/BinaryFileFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/BinaryFileFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class BinaryFileFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'binaryFileField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/CheckboxFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/CheckboxFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class CheckboxFieldTest extends Worker\Field\Boolean
+{
+    protected function getCriterionName()
+    {
+        return 'checkboxField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/ContentIdTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/ContentIdTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the ContentId class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class ContentIdTest extends Worker\Id
+{
+    protected function getCriterionName()
+    {
+        return 'contentId';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/ContentTypeGroupIdTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/ContentTypeGroupIdTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the ContentTypeGroupIdTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class ContentTypeGroupIdTest extends Worker\Id
+{
+    protected function getCriterionName()
+    {
+        return 'contentTypeGroupId';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/ContentTypeIdTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/ContentTypeIdTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the ContentId class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class ContentTypeIdTest extends Worker\Id
+{
+    protected function getCriterionName()
+    {
+        return 'contentTypeId';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/ContentTypeIdentifierTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/ContentTypeIdentifierTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the ContentId class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class ContentTypeIdentifierTest extends Worker\Identifier
+{
+    protected function getCriterionName()
+    {
+        return 'contentTypeIdentifier';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/CountryFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/CountryFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class CountryFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'countryField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/CriterionTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/CriterionTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * File containing the CriterionTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\BaseTest;
+
+abstract class CriterionTest extends BaseTest
+{
+    /**
+     * Returns the name of the criterion being tested
+     * @return string
+     */
+    abstract protected function getCriterionName();
+
+    /**
+     * Returns the criterion string, as used in queries. Usually equals to {@see getCriterionName()}.
+     * @return string
+     */
+    protected function getCriterionString()
+    {
+        return $this->getCriterionName();
+    }
+
+    /**
+     * Tests that the current criterion with $operator and $value matches the built query.
+     *
+     * @param string $operator
+     * @param string $value expected value as a string: "42", or "( 42, 5, 2048 )"
+     */
+    protected function assertQueryMatches( $operator, $value )
+    {
+        $this->assertQueryEquals(
+            sprintf( '%s %s %s', $this->getCriterionString(), strtoupper( $operator ), $value )
+        );
+    }
+
+    /**
+     * Runs the criterion method, and returns the worker
+     */
+    protected function invoke()
+    {
+        $method = $this->getCriterionName();
+        return $this->getQueryBuilder()->$method();
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/DateAndTimeFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/DateAndTimeFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class DateAndTimeFieldTest extends Worker\Field\Date
+{
+    protected function getCriterionName()
+    {
+        return 'dateAndTimeField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/DateFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/DateFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class DateFieldTest extends Worker\Field\Date
+{
+    protected function getCriterionName()
+    {
+        return 'dateField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/DepthTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/DepthTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * File containing the ContentId class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class DepthTest extends Worker\Number
+{
+    public function setUp()
+    {
+        self::markTestSkipped( "Criterion not implemented yet" );
+    }
+    
+    protected function getCriterionName()
+    {
+        return 'depth';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/EmailAddressFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/EmailAddressFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class EmailAddressFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'emailAddressField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/FloatFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/FloatFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class FloatFieldTest extends Worker\Field\Number
+{
+    protected function getCriterionName()
+    {
+        return 'floatField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/FullTextTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/FullTextTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the ContentId class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class FullTextTest extends Worker\Text
+{
+    protected function getCriterionName()
+    {
+        return 'fullText';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/ImageFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/ImageFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class ImageFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'imageField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/IntegerFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/IntegerFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class IntegerFieldTest extends Worker\Field\Number
+{
+    protected function getCriterionName()
+    {
+        return 'integerField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/KeywordFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/KeywordFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class KeywordFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'keywordField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/LocationIdTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/LocationIdTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the LocationRemoteId QueryBuilder API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class LocationIdTest extends Worker\Id
+{
+    protected function getCriterionName()
+    {
+        return 'locationId';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/LocationRemoteIdTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/LocationRemoteIdTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the LocationRemoteId QueryBuilder API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class LocationRemoteIdTest extends Worker\Id
+{
+    protected function getCriterionName()
+    {
+        return 'locationRemoteId';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/MapLocationFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/MapLocationFieldTest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class MapLocationFieldTest extends Worker\Field\Text
+{
+    public function setUp()
+    {
+        self::markTestSkipped( "@todo Implement MapLocationFieldTest" );
+    }
+
+    protected function getCriterionName()
+    {
+        return 'keywordField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/MediaFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/MediaFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class MediaFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'mediaField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/ParentLocationIdTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/ParentLocationIdTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the LocationRemoteId QueryBuilder API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class ParentLocationIdTest extends Worker\Id
+{
+    protected function getCriterionName()
+    {
+        return 'parentLocationId';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/RatingFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/RatingFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class RatingFieldTest extends Worker\Field\Number
+{
+    protected function getCriterionName()
+    {
+        return 'ratingField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/RelationFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/RelationFieldTest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class RelationFieldTest extends Worker\Field\Id
+{
+    public function setUp()
+    {
+        self::markTestSkipped( "@todo Implement RelationFieldTest" );
+    }
+
+    protected function getCriterionName()
+    {
+        return 'relationField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/RelationListFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/RelationListFieldTest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class RelationListFieldTest extends Worker\Field\Id
+{
+    public function setUp()
+    {
+        self::markTestSkipped( "@todo Implement RelationListFieldTest" );
+    }
+
+    protected function getCriterionName()
+    {
+        return 'relationListField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/RichTextFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/RichTextFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class RichTextFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'richTextField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/SectionIdTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/SectionIdTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the ContentId class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class SectionIdTest extends Worker\Identifier
+{
+    protected function getCriterionName()
+    {
+        return 'sectionId';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/SectionIdentifierTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/SectionIdentifierTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * File containing the ContentId class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class SectionIdentifierTest extends Worker\Identifier
+{
+    public function setUp()
+    {
+        self::markTestSkipped( "@todo fix feature" );
+    }
+
+    protected function getCriterionName()
+    {
+        return 'sectionIdentifier';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/TextBlockFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/TextBlockFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class TextBlockFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'textLineField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/TextLineFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/TextLineFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class TextLineFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'textLineField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/TimeFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/TimeFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class TimeFieldTest extends Worker\Field\Date
+{
+    protected function getCriterionName()
+    {
+        return 'timeField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/UrlFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/UrlFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class UrlFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'urlField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/UserFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/UserFieldTest.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class UserFieldTest extends Worker\Field\Text
+{
+    public function setUp()
+    {
+        self::markTestSkipped( "@todo Implement UserFieldTest" );
+    }
+
+    protected function getCriterionName()
+    {
+        return 'userField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/WasCreatedTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/WasCreatedTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * File containing the ContentId class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class WasCreatedTest extends Worker\Date
+{
+    protected function getCriterionName()
+    {
+        return 'wasCreated';
+    }
+
+    protected function getCriterionString()
+    {
+        return 'created';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/WasModifiedTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/WasModifiedTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * File containing the ContentId class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class WasModifiedTest extends Worker\Date
+{
+    protected function getCriterionName()
+    {
+        return 'wasModified';
+    }
+
+    protected function getCriterionString()
+    {
+        return 'modified';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Boolean.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Boolean.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * File containing the Date CriterionTest worker.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\CriterionTest;
+
+/**
+ * @todo Add providers for different input formats
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\BooleanCriterionFactoryWorker invoke()
+ */
+abstract class Boolean extends CriterionTest
+{
+    public function testIsTrue()
+    {
+        $this->invoke()->isTrue();
+        $this->assertQueryMatches( '=',  '1' );
+    }
+
+    public function testIsFalse()
+    {
+        $this->invoke()->isFalse();
+        $this->assertQueryMatches( '=',  '' );
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Date.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Date.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * File containing the Date CriterionTest worker.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\CriterionTest;
+
+/**
+ * @todo Add providers for different input formats
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\DateCriterionFactoryWorker invoke()
+ */
+abstract class Date extends CriterionTest
+{
+    public function testBetween()
+    {
+        self::markTestSkipped( "@todo Feature not implemented" );
+        $this->invoke()->between( 1234567, 1456789 );
+        $this->assertQueryMatches( 'between',  '(1234567, 1456789)' );
+    }
+
+    public function testAt()
+    {
+        $this->invoke()->at( 123456789 );
+        $this->assertQueryMatches( '=',  '123456789' );
+    }
+
+    public function testBefore()
+    {
+        $this->invoke()->before( 123456789 );
+        $this->assertQueryMatches( '<',  '123456789' );
+    }
+
+    public function testAfter()
+    {
+        $this->invoke()->after( 123456789 );
+        $this->assertQueryMatches( '>',  '123456789' );
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Boolean.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Boolean.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * File containing the Date CriterionTest worker.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker\Field;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+/**
+ * @todo Add providers for different input formats
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\DateCriterionFactoryWorker invoke()
+ */
+abstract class Boolean extends Worker\Boolean
+{
+    protected function invoke()
+    {
+        $method = $this->getCriterionName();
+        return $this->getQueryBuilder()->$method( 'identifier' );
+    }
+
+    protected function getCriterionString()
+    {
+        return 'field.identifier';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Date.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Date.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * File containing the Date CriterionTest worker.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker\Field;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+/**
+ * @todo Add providers for different input formats
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\DateCriterionFactoryWorker invoke()
+ */
+abstract class Date extends Worker\Date
+{
+    protected function invoke()
+    {
+        $method = $this->getCriterionName();
+        return $this->getQueryBuilder()->$method( 'identifier' );
+    }
+
+    protected function getCriterionString()
+    {
+        return 'field.identifier';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Id.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Id.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * File containing the Id class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker\Field;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+/**
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\IdCriterionFactoryWorker invoke()
+ */
+abstract class Id extends Worker\Id
+{
+    protected function invoke()
+    {
+        $method = $this->getCriterionName();
+        return $this->getQueryBuilder()->$method( 'identifier' );
+    }
+
+    protected function getCriterionString()
+    {
+        return 'field.identifier';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Identifier.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Identifier.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * File containing the Id class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker\Field;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+/**
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\IdentifierCriterionFactoryWorker invoke()
+ */
+abstract class Identifier extends Worker\Identifier
+{
+    protected function invoke()
+    {
+        $method = $this->getCriterionName();
+        return $this->getQueryBuilder()->$method( 'identifier' );
+    }
+
+    protected function getCriterionString()
+    {
+        return 'field.identifier';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Number.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Number.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * File containing the Number CriterionTest interface.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker\Field;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+/**
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\NumberCriterionFactoryWorker invoke()
+ */
+abstract class Number extends Worker\Number
+{
+    protected function invoke()
+    {
+        $method = $this->getCriterionName();
+        return $this->getQueryBuilder()->$method( 'identifier' );
+    }
+
+    protected function getCriterionString()
+    {
+        return 'field.identifier';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Text.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Field/Text.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * File containing the Number CriterionTest interface.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker\Field;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+/**
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\TextCriterionFactoryWorker invoke()
+ */
+abstract class Text extends Worker\Text
+{
+    protected function invoke()
+    {
+        $method = $this->getCriterionName();
+        return $this->getQueryBuilder()->$method( 'identifier' );
+    }
+
+    protected function getCriterionString()
+    {
+        return 'field.identifier';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Id.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Id.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * File containing the Id class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\CriterionTest;
+
+/**
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\IdCriterionFactoryWorker invoke()
+ */
+abstract class Id extends CriterionTest
+{
+    /**
+     * Tests the eq( $value ) operator
+     */
+    public function testEq()
+    {
+        $this->invoke()->eq( 42 );
+        $this->assertQueryMatches( '=', '42' );
+    }
+
+    /**
+     * Tests the in( v1, v2, ..., vN ) operator
+     */
+    public function testIn()
+    {
+        $this->invoke()->in( 42, 5, 2048 );
+        $this->assertQueryMatches( 'in', '(42, 5, 2048)' );
+    }
+
+    public function testNotIn()
+    {
+        self::markTestIncomplete( "@todo not tested yet" );
+    }
+
+    public function testNotEq()
+    {
+        self::markTestIncomplete( "@todo not tested yet" );
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Identifier.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Identifier.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * File containing the Id class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\CriterionTest;
+
+/**
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\IdentifierCriterionFactoryWorker invoke()
+ */
+abstract class Identifier extends CriterionTest
+{
+    public function testEq()
+    {
+        $this->invoke()->eq( '42' );
+        $this->assertQueryMatches( '=', '42' );
+    }
+
+    public function testIn()
+    {
+        $this->invoke()->in( 'foo', 'bar', 'foobar' );
+        $this->assertQueryMatches( 'in', '(foo, bar, foobar)' );
+    }
+
+    public function testNotIn()
+    {
+        self::markTestIncomplete( "@todo not tested yet" );
+    }
+
+    public function testNotEq()
+    {
+        self::markTestIncomplete( "@todo not tested yet" );
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Number.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Number.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * File containing the Number CriterionTest interface.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\CriterionTest;
+
+/**
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\NumberCriterionFactoryWorker invoke()
+ */
+abstract class Number extends CriterionTest
+{
+    public function testEq()
+    {
+        $this->invoke()->eq( 42 );
+        $this->assertQueryMatches( '=',  '42' );
+    }
+
+    public function testGt()
+    {
+        $this->invoke()->gt( 42 );
+        $this->assertQueryMatches( '>',  '42' );
+    }
+
+    public function testGte()
+    {
+        $this->invoke()->gte( 42 );
+        $this->assertQueryMatches( '>=',  '42' );
+    }
+
+    public function testLt()
+    {
+        $this->invoke()->lt( 42 );
+        $this->assertQueryMatches( '<',  '42' );
+    }
+
+    public function testLte()
+    {
+        $this->invoke()->lte( 42 );
+        $this->assertQueryMatches( '<=',  '42' );
+    }
+
+    public function testBetween()
+    {
+        $this->invoke()->between( 42, 2048 );
+        $this->assertQueryMatches( 'between',  '(42, 2048)' );
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Text.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/Worker/Text.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * File containing the Number CriterionTest interface.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\Worker;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion\CriterionTest;
+
+/**
+ * @method \EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\FactoryWorker\Criterion\TextCriterionFactoryWorker invoke()
+ */
+abstract class Text extends CriterionTest
+{
+    public function testContains()
+    {
+        self::markTestSkipped( "@todo fix criterion, fails. 'contains' == 'like %foo%', currently 'like foo" );
+        $this->invoke()->contains( 'foo' );
+        $this->assertQueryMatches( 'like',  '%foo%' );
+    }
+
+    public function testLike()
+    {
+        $this->invoke()->like( 'foo' );
+        $this->assertQueryMatches( 'like',  'foo' );
+    }
+
+    public function testEndsWith()
+    {
+        $this->invoke()->endsWith( 'foo' );
+        $this->assertQueryMatches( 'like',  '%foo' );
+    }
+
+    public function testBeginsWith()
+    {
+        $this->invoke()->beginsWith( 'foo' );
+        $this->assertQueryMatches( 'like',  'foo%' );
+    }
+
+    public function testMatches()
+    {
+        self::markTestSkipped( "@todo Feature not implemented" );
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/Criterion/XmlTextFieldTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/Criterion/XmlTextFieldTest.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the AuthorTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\Criterion;
+
+class XmlTextFieldTest extends Worker\Field\Text
+{
+    protected function getCriterionName()
+    {
+        return 'xmlTextField';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/ContentIdTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/ContentIdTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the ContentId SortClause API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+class ContentIdTest extends SortClauseTest
+{
+    protected function getMethod()
+    {
+        return 'contentId';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/ContentNameTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/ContentNameTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the ContentName SortClause API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+class ContentNameTest extends SortClauseTest
+{
+    protected function getMethod()
+    {
+        return 'contentName';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/DateModifiedTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/DateModifiedTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the LocationPriority SortClause API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+class DateModifiedTest extends SortClauseTest
+{
+    protected function getMethod()
+    {
+        return 'dateModified';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/DatePublishedTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/DatePublishedTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the LocationPriority SortClause API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+class DatePublishedTest extends SortClauseTest
+{
+    protected function getMethod()
+    {
+        return 'datePublished';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/LocationDepthTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/LocationDepthTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the LocationDepth SortClause API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+class LocationDepthTest extends SortClauseTest
+{
+    protected function getMethod()
+    {
+        return 'locationDepth';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/LocationPathStringTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/LocationPathStringTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the LocationPriority SortClause API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+class LocationPathStringTest extends SortClauseTest
+{
+    protected function getMethod()
+    {
+        return 'locationPathString';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/LocationPathTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/LocationPathTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the LocationPriority SortClause API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+class LocationPathTest extends SortClauseTest
+{
+    protected function getMethod()
+    {
+        return 'locationPath';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/LocationPriorityTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/LocationPriorityTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the LocationPriority SortClause API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+class LocationPriorityTest extends SortClauseTest
+{
+    protected function getMethod()
+    {
+        return 'locationPriority';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/MapLocationDistanceTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/MapLocationDistanceTest.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * File containing the LocationPriority SortClause API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+class MapLocationDistanceTest extends SortClauseTest
+{
+    public function setUp()
+    {
+        self::markTestSkipped( "@todo Fix MapLocationDistanceTest" );
+    }
+
+    protected function getMethod()
+    {
+        return 'mapLocationDistance';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/SectionIdentifierTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/SectionIdentifierTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the LocationPriority SortClause API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+class SectionIdentifierTest extends SortClauseTest
+{
+    protected function getMethod()
+    {
+        return 'sectionIdentifier';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/SectionNameTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/SectionNameTest.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the LocationPriority SortClause API test.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+class SectionNameTest extends SortClauseTest
+{
+    protected function getMethod()
+    {
+        return 'sectionName';
+    }
+}

--- a/eZ/Publish/API/QueryBuilder/Tests/SortClause/SortClauseTest.php
+++ b/eZ/Publish/API/QueryBuilder/Tests/SortClause/SortClauseTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * File containing the SortClausTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\SortClause;
+
+use EzSystems\QueryBuilderBundle\eZ\Publish\API\QueryBuilder\Tests\BaseTest;
+
+/**
+ * Base class for a SortClause API test.
+ *
+ * Calls the criterion provided with
+ */
+abstract class SortClauseTest extends BaseTest
+{
+    /**
+     * Returns the sortBy() QueryBuilder method being tested.
+     * @return string
+     */
+    abstract protected function getMethod();
+
+    /**
+     * Returns the SortClause string representing the generated SortClause. Usually equals to the method name.
+     * @return string
+     */
+    protected function getSortClauseName()
+    {
+        return $this->getMethod();
+    }
+
+
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testAsc( $sortMethod, $expectedSortClauseClass )
+    {
+        $this->getQueryBuilder()->sortBy()->$sortMethod()->asc();
+        $this->assertQueryIsSortedBy( $expectedSortClauseClass, 'ascending' );
+    }
+
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testDesc( $sortMethod, $expectedSortClauseClass )
+    {
+        $this->getQueryBuilder()->sortBy()->$sortMethod()->desc();
+        $this->assertQueryIsSortedBy( $expectedSortClauseClass, 'descending' );
+    }
+
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testAscending( $sortMethod, $expectedSortClauseClass )
+    {
+        $this->getQueryBuilder()->sortBy()->$sortMethod()->ascending();
+        $this->assertQueryIsSortedBy( $expectedSortClauseClass, 'ascending' );
+    }
+
+    /**
+     * @dataProvider methodProvider
+     */
+    public function testDescending( $sortMethod, $expectedSortClauseClass )
+    {
+        $this->getQueryBuilder()->sortBy()->$sortMethod()->descending();
+        $this->assertQueryIsSortedBy( $expectedSortClauseClass, 'descending' );
+    }
+
+    public function methodProvider()
+    {
+        return array(
+            array( $this->getMethod(), $this->getSortClauseName() )
+        );
+    }
+    /**
+     * Tests that the current criterion with $operator and $value matches the built query.
+     * @param string $direction asc or desc
+     */
+    protected function assertQueryIsSortedBy( $sortClauseClass, $direction )
+    {
+        $query = $this->getQueryBuilder()->getQuery();
+        $this->assertEquals(
+            sprintf( "SORT BY %s %s", $sortClauseClass, $direction ),
+            (string)$query
+        );
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
         <testsuite name="QueryBundle test suite">
             <directory>./Tests</directory>
             <directory>./eZ/Publish/Core/QueryBuilder/Tests</directory>
+            <directory>./eZ/Publish/API/QueryBuilder/Tests</directory>
         </testsuite>
     </testsuites>
     <filter>
@@ -19,6 +20,7 @@
                 <directory>vendor/</directory>
                 <directory>Tests/</directory>
                 <directory>eZ/Publish/Core/QueryBuilder/Tests</directory>
+                <directory>eZ/Publish/API/QueryBuilder/Tests</directory>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
> Requires https://github.com/ezsystems/ezpublish-kernel/pull/790
> Requires https://github.com/ezsystems/ezpublish-kernel/pull/789
> Fixes #2 

Implements API tests.

Calls methods from a real query builder instance. Uses the `__toString()` export of queries to assert that the built query is valid.

Depends on a fork of ezpublish-api that has __toString() implemented for queries.
### TODO
- [ ] Remove dependency on fork when PR merged
