### PR TITLE
Added support for query/filter Query properties

### DIFF
--- a/eZ/Publish/Core/QueryBuilder/BaseCriterionBuilder.php
+++ b/eZ/Publish/Core/QueryBuilder/BaseCriterionBuilder.php
@@ -14,6 +14,8 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 
 abstract class BaseCriterionBuilder
 {
+    protected $destination = 'filter';
+
     /**
      * @var CriterionFactoryWorkerRegistry
      */
@@ -23,7 +25,7 @@ abstract class BaseCriterionBuilder
      * Only used when building as an expression builder.
      * @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion[]
      */
-    protected $criterionArray = array();
+    protected $criterionArray = array('filter' => [], 'query' => []);
 
     public function __construct( CriterionFactoryWorkerRegistry $criterionFactoryWorkerRegistry )
     {
@@ -32,7 +34,7 @@ abstract class BaseCriterionBuilder
 
     public function addCriterion( Criterion $criterion )
     {
-        $this->criterionArray[] = $criterion;
+        $this->criterionArray[$this->destination][] = $criterion;
     }
 
     /**

--- a/eZ/Publish/Core/QueryBuilder/BaseQueryBuilder.php
+++ b/eZ/Publish/Core/QueryBuilder/BaseQueryBuilder.php
@@ -33,13 +33,26 @@ abstract class BaseQueryBuilder extends BaseCriterionBuilder implements Criterio
         $this->criterionBuilder = new CriterionBuilder( $this->criterionFactoryWorkerRegistry, $this );
     }
 
+    public function filter()
+    {
+        $this->destination = 'filter';
+
+        return $this;
+    }
+
+    public function query()
+    {
+        $this->destination = 'query';
+
+        return $this;
+    }
+
     public function getQuery()
     {
-        if ( count( $this->criterionArray ) == 1 && ( $this->criterionArray[0] instanceof Criterion\LogicalAnd || $this->criterionArray[0] instanceof Criterion\LogicalOr ) )
-            $this->query->filter = $this->criterionArray[0];
-        else
-            $this->query->filter = new Criterion\LogicalAnd( $this->criterionArray );
+        $this->query->filter = $this->getCriterion($this->criterionArray['filter']);
+        $this->query->query = $this->getCriterion($this->criterionArray['query']);
         $this->query->sortClauses = $this->sortClauseArray;
+
         return $this->query;
     }
 
@@ -56,5 +69,14 @@ abstract class BaseQueryBuilder extends BaseCriterionBuilder implements Criterio
     public function expr()
     {
         return new CriterionBuilder( $this->criterionFactoryWorkerRegistry );
+    }
+
+    private function getCriterion(array $array)
+    {
+        if (count($array) == 1 && ($array[0] instanceof Criterion\LogicalAnd || $array[0] instanceof Criterion\LogicalOr)) {
+            return $array[0];
+        } else {
+            return new Criterion\LogicalAnd($array);
+        }
     }
 }


### PR DESCRIPTION
`filter()` and `query()` methods on the builder will switch from one to the other:

```
$builder
  ->filter()
    ->someFilterHere()
  ->query()
    ->someCriterion()
  ->getQuery();
```
### TODO
- [ ] Add to phpdoc & interfaces
